### PR TITLE
Backup-data: remove .ssh directory from backup

### DIFF
--- a/root/etc/backup-data.d/nethserver-backup-data.exclude
+++ b/root/etc/backup-data.d/nethserver-backup-data.exclude
@@ -1,2 +1,3 @@
 /var/lib/nethserver/backup/duplicity/
 /var/lib/nethserver/db
+/root/.ssh


### PR DESCRIPTION
Remove .shh directory from backup-data to avoid conflicts with backup-config.
NethServer/dev#5269