### PR TITLE
Do not run backup-config

### DIFF
--- a/root/sbin/e-smith/backup-data
+++ b/root/sbin/e-smith/backup-data
@@ -49,10 +49,6 @@ if ( -e $logFile) {
    unlink($logFile);
 }
 
-# Make sure configuration backup is updated
-system('/sbin/e-smith/backup-config');
-
-
 $backup->cleanup_notification();
 $backup->notify("===== Report for data backup =====\n");
 


### PR DESCRIPTION
The backup-config package hooks an action on pre-backup-data event.

Partially reverts dcdf827

NethServer/dev#5314

See also http://dev.nethserver.org/issues/2118