### PR TITLE
Exclude lastlog log

### DIFF
--- a/root/etc/backup-data.d/nethserver-backup-data.exclude
+++ b/root/etc/backup-data.d/nethserver-backup-data.exclude
@@ -1,3 +1,4 @@
 /var/lib/nethserver/backup/duplicity/
 /var/lib/nethserver/db
 /root/.ssh
+/var/log/lastlog


### PR DESCRIPTION
Duplicity can't correctly handle sparse files.

See:
 - https://bugs.launchpad.net/duplicity/+bug/1548549
 - http://www.noah.org/wiki/Lastlog_is_gigantic

NethServer/dev#5470