### PR TITLE
restore-file: remove bad argument

### DIFF
--- a/root/sbin/e-smith/restore-file
+++ b/root/sbin/e-smith/restore-file
@@ -70,7 +70,6 @@ if ( ($VFSType eq 'usb') || ($VFSType eq 'nfs') || ($VFSType eq 'cifs') || ($VFS
    }
    push(@args,  $dst_path);
    foreach (@files) {
-       push(@args, '--file-to-restore');
        push(@args, $_);
    }
    system(@args);


### PR DESCRIPTION
The restore-data-duplicity helper doesn't need '--file-to-restore' option.

NethServer/dev#5496