### PR TITLE
nethserver-backup-data.exclude: exclude restic cache dir from backup

### DIFF
--- a/root/etc/backup-data.d/nethserver-backup-data.exclude
+++ b/root/etc/backup-data.d/nethserver-backup-data.exclude
@@ -1,3 +1,4 @@
+/var/lib/nethserver/backup/restic/
 /var/lib/nethserver/backup/duplicity/
 /var/lib/nethserver/db
 /root/.ssh


### PR DESCRIPTION
Restic uses _--exclude-caches_ to exclude its cache, but when both restic and rsync are used on the same system restic cache is copied by rsync (which doesn't support CACHEDIR.TAG).

