### PR TITLE
Skip filesystems mount

### DIFF
--- a/root/etc/e-smith/events/actions/mount-cifs
+++ b/root/etc/e-smith/events/actions/mount-cifs
@@ -40,9 +40,12 @@ my $smbshare = $backupwk->prop('SMBShare');
 my $login = $backupwk->prop('SMBLogin');
 my $password = $backupwk->prop('SMBPassword');
 my $VFSType = $backupwk->prop('VFSType') || 'UNKNOWN';
+my $status = $backupwk->prop('status') || 'disabled';
 our $mntdir = $backupwk->prop('Mount') || '/mnt/backup';
 my $err = 0;
 my $mntdone = 0;
+
+exit 0 if ($status eq 'disabled');
 
 exit 0 unless ($VFSType eq 'cifs');
 

--- a/root/etc/e-smith/events/actions/mount-nfs
+++ b/root/etc/e-smith/events/actions/mount-nfs
@@ -38,9 +38,12 @@ my $backupwk = $confdb->get('backup-data') or die "No backup-data db entry found
 my $nfshost = $backupwk->prop('NFSHost');
 my $nfsshare = $backupwk->prop('NFSShare');
 my $VFSType = $backupwk->prop('VFSType') || 'UNKNOWN';
+my $status = $backupwk->prop('status') || 'disabled';
 our $mntdir = $backupwk->prop('Mount') || '/mnt/backup';
 my $err = 0;
 my $mntdone = 0;
+
+exit 0 if ($status eq 'disabled');
 
 exit 0 unless ($VFSType eq 'nfs');
 

--- a/root/etc/e-smith/events/actions/mount-usb
+++ b/root/etc/e-smith/events/actions/mount-usb
@@ -35,9 +35,12 @@ sub ldie;
 my $confdb = esmith::ConfigDB->open;
 my $backupwk = $confdb->get('backup-data') or die "No backup-data db entry found\n";
 my $VFSType = $backupwk->prop('VFSType') || 'UNKNOWN';
+my $status = $backupwk->prop('status') || 'disabled';
 our $mntdir = $backupwk->prop('Mount') || '/mnt/backup';
 my $err = 0;
 my $mntdone = 0;
+
+exit 0 if ($status eq 'disabled');
 
 exit 0 unless ($VFSType eq 'usb');
 my $usblabel = $backupwk->prop('USBLabel') || die "No USBLabel set";


### PR DESCRIPTION
Do not mount filesystems if backup is disabled.
Avoid errors during upgrade from NS 6 to NS 7

Backport of NethServer/dev#5655
Refs #3451(http://dev.nethserver.org/issues/3451)