### PR TITLE
CIFS: try to mount with old protocol

### DIFF
--- a/root/etc/e-smith/events/actions/mount-cifs
+++ b/root/etc/e-smith/events/actions/mount-cifs
@@ -79,9 +79,14 @@ if (!$b->is_mounted("\/$smbhost(.*)\/$smbshare") && !$b->is_mounted($mntdir)) {
 
     # mount the backup dir
     $err = qx(/bin/mount -t cifs "//$smbhost/$smbshare" $mntdir -o credentials=$tmp,nounix 2>&1);
-    if ($err) {
-        $err =~s/\n/ /g;
-        ldie("Error while mounting $smbhost:$smbshare : " . $err); 
+    if ($? > 0) {
+        # HACK: try to mount using old CIFS version
+        $err = qx(/bin/mount -t cifs "//$smbhost/$smbshare" $mntdir -o credentials=$tmp,nounix,vers=1.0 2>&1);
+    } else {
+        if ($err) {
+            $err =~s/\n/ /g;
+            ldie("Error while mounting $smbhost:$smbshare : " . $err);
+        }
     }
 }
 


### PR DESCRIPTION
Protocols 2.1 and 3.0 should be auto-negotiated by clients,
but old insecure 1.0 protocol must be explicitly set.

NethServer/dev#5687