### PR TITLE
dav2fs: support multiple backup

### DIFF
--- a/root/etc/e-smith/events/actions/mount-webdav
+++ b/root/etc/e-smith/events/actions/mount-webdav
@@ -38,9 +38,14 @@ sub ldie;
 my $event = shift || die("No event given");
 my $name = shift || 'backup-data';
 
-exit 0 if ($name ne 'backup-data');
+my $db;
 
-my $db = esmith::ConfigDB->open_ro();
+if ($name eq 'backup-data') {
+    $db = esmith::ConfigDB->open_ro();
+} else {
+    $db = esmith::ConfigDB->open_ro('backups') || die("Could not open backups db\n");
+}
+
 my $mntdir = "/mnt/backup-$name";
 my $backupwk = $db->get($name) || die("No '$name' db entry found\n");
 

--- a/root/etc/e-smith/templates/etc/davfs2/davfs2.conf/80backup_mount_point
+++ b/root/etc/e-smith/templates/etc/davfs2/davfs2.conf/80backup_mount_point
@@ -5,6 +5,15 @@
 {
     $OUT .= "[/mnt/backup-backup-data]\n";
     $OUT .= "ask_auth\t0\n";
-}
 
+    use esmith::ConfigDB;
+    my $db = esmith::ConfigDB->open_ro('backups') || return '';
+    foreach ($db->get_all()) {
+        my $vfstype = $_->prop('VFSType') || next;
+        if ($vfstype eq 'webdav') {
+            $OUT .= "[/mnt/backup-".$_->key."]\n";
+            $OUT .= "ask_auth\t0\n\n";
+        }
+    }
+}
 

--- a/root/etc/e-smith/templates/etc/davfs2/secrets/30credentials
+++ b/root/etc/e-smith/templates/etc/davfs2/secrets/30credentials
@@ -24,6 +24,17 @@
                 $OUT .= "\"/mnt/backup-backup-data\"\t".$backup{WebDAVLogin}."\t\"".$backup{'WebDAVPassword'}."\"\n";
         }
 
+    use esmith::ConfigDB;
+    my $db = esmith::ConfigDB->open_ro('backups') || return '';
+    foreach ($db->get_all()) {
+        my $vfstype = $_->prop('VFSType') || next;
+        my $login = $_->prop('WebDAVLogin') || next;
+        my $pass = $_->prop('WebDAVPassword') || next;
+        if ($vfstype eq 'webdav') {
+            $OUT .= "\"/mnt/backup-".$_->key."\"\t$login\t\"$pass\"\n";
+        }
+    }
+
 }
 
 


### PR DESCRIPTION
This is required to migrate the single backup (backup-data) to a normal multiple backup.

Modifications doesn't change current behavior for the single backup.

During the development I also fixed a minor issue: https://github.com/NethServer/nethserver-backup-config/commit/dcd6307fd70cc0f58408ab086fb2d784e7419c23