### PR TITLE
backup-data command: improved help message

### DIFF
--- a/root/sbin/e-smith/backup-data
+++ b/root/sbin/e-smith/backup-data
@@ -29,29 +29,43 @@ use Getopt::Std;
 use constant MAX_TIME => 300;
 use constant DEBUG => 0;
 
-sub print_help
+sub help_message
 {
-    print "Usage $0 [-b <backup_name>] [-h]\n";
-    print "  -b : specify the name of backup to use\n";
-    print "  -h : show this help\n";
+    my $backup_command_list = "";
+    foreach ($_[0]->get_all()) {
+        $backup_command_list .= "  $0 -b " . $_->key . "\n"
+    }
+
+    my $appendix = "";
+
+    if (length($backup_command_list)) {
+        $appendix = "Use one of the following commands:\n" . $backup_command_list
+    } else {
+        $appendix = "There is no backup configuration\n"
+    }
+
+    return "Usage $0 [-b <backup_name>] [-h]\n" .
+            "  -b : specify the name of backup to use\n" .
+            "  -h : show this help\n\n" .
+            $appendix
 }
 
 my %options=();
 getopts("hb:", \%options);
 my $help = $options{h};
-my $name = $options{b} || die("No name given");
+my $db = esmith::ConfigDB->open_ro('backups') || die("Could not open backups db\n");
 
-if ($help)
+if (defined $help)
 {
-  print_help();
+  print help_message($db);
   exit(0);
 }
 
+my $name = $options{b} || die(help_message($db));
 my $status;
 my %du;
 my $timeout = 0;
 my $conf = esmith::ConfigDB->open || die("Could not open config db\n");
-my $db = esmith::ConfigDB->open_ro('backups') || die("Could not open backups db\n");
 my $backup = $db->get($name) || die("No backup '$name' found");
 my $program = $backup->prop('type') || 'duplicity';
 out("Backup: $name");


### PR DESCRIPTION
After introduction of multiple backups, the syntax changed: let's help some users on how to use the command