### PR TITLE
migrate. avoid empty backup record

### DIFF
--- a/root/etc/e-smith/db/configuration/migrate/issue5691
+++ b/root/etc/e-smith/db/configuration/migrate/issue5691
@@ -31,7 +31,9 @@
     }
 
     # move all remaining props to new record
-    $bdb->new_record('backup-data', \%props); 
+    if(scalar keys %props > 0) {
+        $bdb->new_record('backup-data', \%props);
+    }
     '';
 }
 


### PR DESCRIPTION
On new installations, the backup-data on configuration db does not exists anymore, the migration fragment create **always** a migrated empty record inside the `backups` database.

This PR take care of the previous props inside the configuration database and create a new record **only** if a previous backup-data was configured.

Tested both in NethGUI and Cockpit, the missing record does not brake the interface behavior