### PR TITLE
backup-data-wrapper. move epoch before backup exec

### DIFF
--- a/root/sbin/e-smith/backup-data-wrapper
+++ b/root/sbin/e-smith/backup-data-wrapper
@@ -28,6 +28,7 @@
 
 backup=$1
 ts=$(date +%Y%m%d%H%M)
+epoch=$(date +%s)
 cmd="/sbin/e-smith/backup-data -b $backup"
 out_dir="/var/log/backup"
 
@@ -40,7 +41,6 @@ log="${out_dir}/backup-${backup}-${ts}.log"
 output=$($cmd 2>&1 | tee "$log")
 exit_code=$?
 
-epoch=$(date +%s)
 # exec all scripts inside /etc/backup-data.hooks
 for file in /etc/backup-data.hooks/*; do
     [ -f "$file" ] && [ -x "$file" ] && "$file" "$backup" "$log" $exit_code "$epoch"


### PR DESCRIPTION
* avoid different timestamp from backup starts and ends

Nethserver/dev#5975