### PR TITLE
hotsync. avoid backup execution on slave

### DIFF
--- a/root/sbin/e-smith/backup-data
+++ b/root/sbin/e-smith/backup-data
@@ -66,6 +66,18 @@ my $status;
 my %du;
 my $timeout = 0;
 my $conf = esmith::ConfigDB->open || die("Could not open config db\n");
+
+my $hotsync = $conf->get('hotsync') || 0;
+
+if ($hotsync != 0) {
+    my $hsRole = $hotsync->prop('role')  || "";
+    my $hsStatus = $hotsync->prop('status')  || "disabled";
+
+    if ($hsRole eq "slave" && $hsStatus eq "enabled") {
+      error('Backup-data is not allowed on slave host. Please disable it.');
+    }
+}
+
 my $backup = $db->get($name) || die("No backup '$name' found");
 my $program = $backup->prop('type') || 'duplicity';
 


### PR DESCRIPTION
If host is slave and hotsync is enabled backup-data is not allowed.
Refer to https://github.com/NethServer/dev/issues/6013