### PR TITLE
davfs: immediately upload backup files

### DIFF
--- a/root/etc/e-smith/templates/etc/davfs2/davfs2.conf/80backup_mount_point
+++ b/root/etc/e-smith/templates/etc/davfs2/davfs2.conf/80backup_mount_point
@@ -9,6 +9,7 @@
         my $vfstype = $_->prop('VFSType') || next;
         if ($vfstype eq 'webdav') {
             $OUT .= "[/mnt/backup-".$_->key."]\n";
+            $OUT .= "delay_upload\t0\n";
             $OUT .= "ask_auth\t0\n\n";
         }
     }


### PR DESCRIPTION
By default, davfs delays upload to avoid sending temporary files.
Waiting 10 seconds before upload, with a high volume data producer such a backup, quickly fills up the davfs cache resulting in thousands of log lines:
`mount.davfs: open files exceed max cache size by 10345 MiBytes`
Moreover, it seems that when dealing with a full cache, davfs stops respecting size limits (I found a cache of 22G, the limits is 50M).
The NethServer backup folder contains files that should be uploaded.
Applying the proposed fix to the system allowed davfs to trim the cache to 50M by itself (and those messages disappeared, btw).
