### PR TITLE
Fix ns6 upgrade main event failure

### DIFF
--- a/root/etc/e-smith/templates/etc/ssh/ssh_config/20backup_hosts
+++ b/root/etc/e-smith/templates/etc/ssh/ssh_config/20backup_hosts
@@ -3,7 +3,7 @@
 #
 {
     use esmith::ConfigDB;
-    my $db = esmith::ConfigDB->open_ro('backups');
+    my $db = esmith::ConfigDB->open_ro('backups') || return "";
     foreach my $backup ($db->get_all()) {
         my $status = $backup->prop('status') || 'disabled';
         my $vfs = $backup->prop('VFSType') || next;


### PR DESCRIPTION
The backups database is not present when this template is expanded in the post-restore-config event.

This issue was reported within the ns6 upgrade procedure.

See also NethServer/dev#6304

NethServer/dev#6330