### PR TITLE
Fix failed ns6 upgrade event

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -58,11 +58,4 @@ event_actions($event,
    'cleanup-data-duplicity' => '70',
 );
 
-#--------------------------------------------------
-# actions for post-restore-config event
-#--------------------------------------------------
-
-$event = "post-restore-config";
-templates2events("/etc/ssh/ssh_config",  $event);
-
 exit;

--- a/createlinks
+++ b/createlinks
@@ -32,7 +32,7 @@ templates2events("/etc/cron.d/backup-data",  $event);
 templates2events("/etc/davfs2/davfs2.conf",  $event);
 templates2events("/etc/davfs2/secrets",  $event);
 templates2events("/etc/backup-data.d/nethserver-backup-data.include",  $event);
-
+templates2events("/etc/ssh/ssh_config",  $event);
 
 #--------------------------------------------------
 # actions for nethserver-backup-data-save event


### PR DESCRIPTION
During ns6 upgrade procedure the backups database is not present when /etc/ssh_config is expanded in the post-restore-config event.

The template expansion is already executed in post-restore-config by the system-adjust action, so we can delete here.

Obsoletes #59

See also https://github.com/NethServer/dev/issues/6304

https://github.com/NethServer/dev/issues/6330